### PR TITLE
feat(release): Add goreleaser and template processing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           check-latest: true
 
       - name: Build binaries
-        run: make build
+        run: VERSION=${{ github.event.inputs.tag }} make build
 
       - name: Create archives
         run: |

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,90 @@
+# GoReleaser configuration for YankRun
+# See https://goreleaser.com/customization/ for more details
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - 386
+      - arm
+    ldflags:
+      - -s -w
+      - -X main.Version={{.Version}}
+      - -X main.BuildTime={{.Date}}
+      - -X main.GitCommit={{.FullCommit}}
+    binary: yankrun-{{.OS}}-{{.Arch}}
+    ignore:
+      - goos: windows
+        goarch: arm
+
+archives:
+  - format: tar.gz
+    name_template: "yankrun-{{.OS}}-{{.Arch}}"
+    files:
+      - README.md
+      - LICENSE
+    format_overrides:
+      - goos: windows
+        format: zip
+        name_template: "yankrun-{{.OS}}-{{.Arch}}"
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+release:
+  github:
+    owner: brasa-ai
+    name: yankrun
+  draft: false
+  prerelease: auto
+  name_template: "Release {{ .Tag }}"
+  footer: |
+    ## Installation
+
+    ### Linux/macOS (AMD64)
+    ```bash
+    curl -L https://github.com/brasa-ai/yankrun/releases/download/{{ .Tag }}/yankrun-linux-amd64.tar.gz -o yankrun-linux-amd64.tar.gz
+    tar -xvf yankrun-linux-amd64.tar.gz yankrun-linux-amd64
+    chmod +x yankrun-linux-amd64
+    sudo mv yankrun-linux-amd64 /usr/local/bin/yankrun
+    ```
+
+    ### Linux/macOS (ARM64)
+    ```bash
+    curl -L https://github.com/brasa-ai/yankrun/releases/download/{{ .Tag }}/yankrun-linux-arm64.tar.gz -o yankrun-linux-arm64.tar.gz
+    tar -xvf yankrun-linux-arm64.tar.gz yankrun-linux-arm64
+    chmod +x yankrun-linux-arm64
+    sudo mv yankrun-linux-arm64 /usr/local/bin/yankrun
+    ```
+
+    ### Windows
+    ```powershell
+    Invoke-WebRequest -Uri https://github.com/brasa-ai/yankrun/releases/download/{{ .Tag }}/yankrun-windows-amd64.zip -OutFile yankrun-windows-amd64.zip
+    Expand-Archive -Path yankrun-windows-amd64.zip -DestinationPath .
+    Move-Item -Path yankrun-windows-amd64/yankrun-windows-amd64.exe -Destination yankrun.exe
+    ```
+
+    ### From Source
+    ```bash
+    go install github.com/brasa-ai/yankrun@{{ .Tag }}
+    ```

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,28 @@
-.PHONY: all build clean
+.PHONY: all build clean version
 
 GOOS_ARCH := linux/amd64 linux/arm64 linux/386 linux/arm darwin/amd64 darwin/arm64 windows/amd64 windows/arm64 windows/386
 DIST_DIR := dist
+
+# Version information - can be overridden by environment variable
+ifeq ($(origin VERSION), environment)
+  # VERSION is set from environment
+else
+  VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+endif
+
+BUILD_TIME := $(shell date -u '+%Y-%m-%d_%H:%M:%S')
+GIT_COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+
+# Build flags
+LDFLAGS := -ldflags="-s -w -X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME) -X main.GitCommit=$(GIT_COMMIT)"
 
 all: build
 
 build:
 	@echo "Building binaries..."
+	@echo "Version: $(VERSION)"
+	@echo "Build time: $(BUILD_TIME)"
+	@echo "Git commit: $(GIT_COMMIT)"
 	@mkdir -p $(DIST_DIR)
 	@for t in $(GOOS_ARCH); do \
 		os=$${t%/*}; arch=$${t#*/}; \
@@ -14,7 +30,7 @@ build:
 		if [ "$$os" = "windows" ]; then bin_name="$${bin_name}.exe"; fi; \
 		bin_path=$(DIST_DIR)/$$bin_name; \
 		echo "  Building for $$os/$$arch..."; \
-		GOOS=$$os GOARCH=$$arch go build -ldflags="-s -w" -o $$bin_path .; \
+		GOOS=$$os GOARCH=$$arch go build $(LDFLAGS) -o $$bin_path .; \
 	done
 	@echo "Build complete. Binaries in $(DIST_DIR)/"
 
@@ -22,5 +38,26 @@ clean:
 	@echo "Cleaning build artifacts..."
 	rm -rf $(DIST_DIR)
 	@echo "Clean complete."
+
+version:
+	@echo "Current version: $(VERSION)"
+	@echo "Build time: $(BUILD_TIME)"
+	@echo "Git commit: $(GIT_COMMIT)"
+
+# Create a git tag for the current version
+tag:
+	@if [ "$(VERSION)" = "dev" ]; then \
+		echo "Error: Cannot tag dev version. Please set VERSION environment variable."; \
+		exit 1; \
+	fi
+	@echo "Creating git tag: $(VERSION)"
+	git tag -a $(VERSION) -m "Release $(VERSION)"
+	@echo "Tag created. Push with: git push origin $(VERSION)"
+
+# Build and test before release
+release-check: build
+	@echo "Running tests..."
+	go test ./...
+	@echo "All tests passed. Ready for release $(VERSION)"
 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Template smarter: clone repos and replace tokens safely with size limits, custom
 -   **Verbose reporting**
 -   **JSON/YAML inputs** and ignore patterns
 -   **Transformation functions** (`toUpperCase`, `toLowerCase`, `gsub`)
+-   **Template file processing** (`.tpl` files processed and renamed)
 
 ## Install
 
@@ -145,6 +146,7 @@ Options:
 - `--startDelim`: template start delimiter (default `[[`)
 - `--endDelim`: template end delimiter (default `]]`)
 - `--prompt` (alias: `--interactive`): ask for values before applying
+- `--processTemplates` (alias: `--pt`): process `.tpl` files by evaluating templates and removing `.tpl` suffix
 
 </details>
 
@@ -191,6 +193,35 @@ What it does:
 - Shows a summary of each placeholder with how many matches were found.
 - Pre-fills values from `-i` if provided; prompts for missing ones.
 - Applies replacements across the directory and prints a completion message.
+
+</details>
+
+<details>
+<summary><strong>Template File Processing</strong></summary>
+
+YankRun can process `.tpl` files by evaluating their template content and removing the `.tpl` suffix. This is useful when you have template files that should be processed and renamed.
+
+```sh
+# Process .tpl files in addition to regular templating
+yankrun template --dir ./project --input values.json --processTemplates --verbose
+
+# Clone and process .tpl files
+yankrun clone --repo https://github.com/user/template.git --input values.yaml --processTemplates
+```
+
+What it does:
+- Finds all files ending with `.tpl` in the target directory (recursively)
+- Evaluates template placeholders in these files using the same replacement logic
+- Creates new files without the `.tpl` suffix containing the processed content
+- Removes the original `.tpl` files
+- Skips `.tpl` files in ignored directories (`.git`, `node_modules`, `vendor`, etc.)
+
+Example:
+- `README.tpl` → `README` (with placeholders replaced)
+- `config.tpl` → `config` (with placeholders replaced)
+- `src/main.tpl` → `src/main` (with placeholders replaced)
+
+The `--processTemplates` flag is optional and defaults to `false` to maintain backward compatibility.
 
 </details>
 

--- a/actions/clone.go
+++ b/actions/clone.go
@@ -1,17 +1,17 @@
 package actions
 
 import (
-    "bufio"
-    "fmt"
-    "os"
-    "sort"
-    "strings"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
 
-    "github.com/brasa-ai/yankrun/domain"
-    "github.com/brasa-ai/yankrun/helpers"
-    "github.com/brasa-ai/yankrun/services"
+	"github.com/brasa-ai/yankrun/domain"
+	"github.com/brasa-ai/yankrun/helpers"
+	"github.com/brasa-ai/yankrun/services"
 
-    "github.com/urfave/cli"
+	"github.com/urfave/cli"
 )
 
 type CloneAction struct {
@@ -36,100 +36,122 @@ func (a *CloneAction) Execute(c *cli.Context) error {
 	verbose := c.Bool("verbose")
 	input := c.String("input")
 	fileSizeLimit := c.String("fileSizeLimit")
-    startDelim := c.String("startDelim")
-    endDelim := c.String("endDelim")
-    interactive := c.Bool("interactive")
+	startDelim := c.String("startDelim")
+	endDelim := c.String("endDelim")
+	interactive := c.Bool("interactive")
+	processTemplates := c.Bool("processTemplates")
 
-    // Load defaults from config when flags not provided
-    cfg, _ := services.Load()
-    if cfg == nil {
-        cfg = &domain.Config{}
-    }
-    if startDelim == "" && cfg.StartDelim != "" {
-        startDelim = cfg.StartDelim
-    }
-    if endDelim == "" && cfg.EndDelim != "" {
-        endDelim = cfg.EndDelim
-    }
-    if fileSizeLimit == "" && cfg.FileSizeLimit != "" {
-        fileSizeLimit = cfg.FileSizeLimit
-    }
-    if startDelim == "" { startDelim = "[[" }
-    if endDelim == "" { endDelim = "]]" }
-    if fileSizeLimit == "" {
-        fileSizeLimit = "3 mb"
-    }
+	// Load defaults from config when flags not provided
+	cfg, _ := services.Load()
+	if cfg == nil {
+		cfg = &domain.Config{}
+	}
+	if startDelim == "" && cfg.StartDelim != "" {
+		startDelim = cfg.StartDelim
+	}
+	if endDelim == "" && cfg.EndDelim != "" {
+		endDelim = cfg.EndDelim
+	}
+	if fileSizeLimit == "" && cfg.FileSizeLimit != "" {
+		fileSizeLimit = cfg.FileSizeLimit
+	}
+	if startDelim == "" {
+		startDelim = "[["
+	}
+	if endDelim == "" {
+		endDelim = "]]"
+	}
+	if fileSizeLimit == "" {
+		fileSizeLimit = "3 mb"
+	}
 
 	if err := a.fs.EnsureDir(outputDir); err != nil {
 		return err
 	}
 
-    if err := a.cloner.CloneRepository(repoURL, outputDir); err != nil {
-        return err
-    }
+	if err := a.cloner.CloneRepository(repoURL, outputDir); err != nil {
+		return err
+	}
 
-    helpers.Log.Info().Msgf("Cloned into %s", outputDir)
+	helpers.Log.Info().Msgf("Cloned into %s", outputDir)
 
-    // Parse provided replacements if any
-    var provided domain.InputReplacement
-    if input != "" {
-        var err error
-        provided, err = a.parser.Parse(input)
-        if err != nil {
-            return err
-        }
-    }
+	// Parse provided replacements if any
+	var provided domain.InputReplacement
+	if input != "" {
+		var err error
+		provided, err = a.parser.Parse(input)
+		if err != nil {
+			return err
+		}
+	}
 
-    // Analyze placeholders in cloned directory
-    counts, err := a.replacer.AnalyzeDir(outputDir, fileSizeLimit, startDelim, endDelim)
-    if err != nil {
-        return err
-    }
+	// Analyze placeholders in cloned directory
+	counts, err := a.replacer.AnalyzeDir(outputDir, fileSizeLimit, startDelim, endDelim)
+	if err != nil {
+		return err
+	}
 
-    // Build value map from provided input
-    values := map[string]string{}
-    for _, r := range provided.Variables { values[r.Key] = r.Value }
+	// Build value map from provided input
+	values := map[string]string{}
+	for _, r := range provided.Variables {
+		values[r.Key] = r.Value
+	}
 
-    // If interactive, prompt for each discovered key
-    final := domain.InputReplacement{}
-    if len(counts) > 0 {
-        keys := make([]string, 0, len(counts))
-        for k := range counts { keys = append(keys, k) }
-        sort.Strings(keys)
+	// If interactive, prompt for each discovered key
+	final := domain.InputReplacement{}
+	if len(counts) > 0 {
+		keys := make([]string, 0, len(counts))
+		for k := range counts {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
 
-        helpers.Log.Info().Msg("Discovered placeholders:")
-        for _, k := range keys {
-            v := values[k]
-            if v == "" { v = "(unset)" }
-            fmt.Printf("  %-24s  matches=%-6d  value=%s\n", k, counts[k], v)
-        }
+		helpers.Log.Info().Msg("Discovered placeholders:")
+		for _, k := range keys {
+			v := values[k]
+			if v == "" {
+				v = "(unset)"
+			}
+			fmt.Printf("  %-24s  matches=%-6d  value=%s\n", k, counts[k], v)
+		}
 
-        if interactive {
-            r := bufio.NewReader(os.Stdin)
-            for _, k := range keys {
-                def := values[k]
-                fmt.Printf("Enter value for %s [%s]: ", k, def)
-                s, _ := r.ReadString('\n')
-                s = strings.TrimSpace(s)
-                if s != "" { values[k] = s }
-            }
-            fmt.Println()
-        }
+		if interactive {
+			r := bufio.NewReader(os.Stdin)
+			for _, k := range keys {
+				def := values[k]
+				fmt.Printf("Enter value for %s [%s]: ", k, def)
+				s, _ := r.ReadString('\n')
+				s = strings.TrimSpace(s)
+				if s != "" {
+					values[k] = s
+				}
+			}
+			fmt.Println()
+		}
 
-        for _, k := range keys {
-            if v, ok := values[k]; ok && v != "" {
-                final.Variables = append(final.Variables, domain.Replacement{Key: k, Value: v})
-            }
-        }
-    } else {
-        // No discovered keys; use provided values directly
-        final = provided
-    }
+		for _, k := range keys {
+			if v, ok := values[k]; ok && v != "" {
+				final.Variables = append(final.Variables, domain.Replacement{Key: k, Value: v})
+			}
+		}
+	} else {
+		// No discovered keys; use provided values directly
+		final = provided
+	}
 
-    if err := a.replacer.ReplaceInDir(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
-        return err
-    }
-    helpers.Log.Info().Msg("Templating complete ✔")
+	if err := a.replacer.ReplaceInDir(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+		return err
+	}
+
+	// Process .tpl files if requested
+	if processTemplates {
+		if err := a.replacer.ProcessTemplateFiles(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+			return err
+		}
+		helpers.Log.Info().Msg("Template file processing complete ✔")
+	}
+
+	helpers.Log.Info().Msg("Templating complete ✔")
 
 	return nil
 }

--- a/actions/generate.go
+++ b/actions/generate.go
@@ -38,6 +38,7 @@ func (a *GenerateAction) Execute(c *cli.Context) error {
     outputDir := c.String("outputDir")
     templateFilter := c.String("template")
     branchFlag := c.String("branch")
+    processTemplates := c.Bool("processTemplates")
 
     cfg, err := services.Load()
     if err != nil {
@@ -250,6 +251,15 @@ func (a *GenerateAction) Execute(c *cli.Context) error {
     if err := a.replacer.ReplaceInDir(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
         return err
     }
+    
+    // Process .tpl files if requested
+    if processTemplates {
+        if err := a.replacer.ProcessTemplateFiles(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+            return err
+        }
+        helpers.Log.Info().Msg("Template file processing complete ✔")
+    }
+    
     helpers.Log.Info().Msg("Templating complete ✔")
     return nil
 }

--- a/actions/template.go
+++ b/actions/template.go
@@ -1,113 +1,147 @@
 package actions
 
 import (
-    "bufio"
-    "fmt"
-    "os"
-    "sort"
-    "strings"
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
 
-    "github.com/brasa-ai/yankrun/domain"
-    "github.com/brasa-ai/yankrun/helpers"
-    "github.com/brasa-ai/yankrun/services"
+	"github.com/brasa-ai/yankrun/domain"
+	"github.com/brasa-ai/yankrun/helpers"
+	"github.com/brasa-ai/yankrun/services"
 
-    "github.com/urfave/cli"
+	"github.com/urfave/cli"
 )
 
 type TemplateAction struct {
-    fs       services.FileSystem
-    parser   services.ReplacementParser
-    replacer services.Replacer
+	fs       services.FileSystem
+	parser   services.ReplacementParser
+	replacer services.Replacer
 }
 
 func NewTemplateAction(fs services.FileSystem, parser services.ReplacementParser, replacer services.Replacer) *TemplateAction {
-    return &TemplateAction{fs: fs, parser: parser, replacer: replacer}
+	return &TemplateAction{fs: fs, parser: parser, replacer: replacer}
 }
 
 func (t *TemplateAction) Execute(c *cli.Context) error {
-    inputFile := c.String("input")
-    dir := c.String("dir")
-    verbose := c.Bool("verbose")
-    interactive := c.Bool("interactive")
-    startDelim := c.String("startDelim")
-    endDelim := c.String("endDelim")
-    fileSizeLimit := c.String("fileSizeLimit")
+	inputFile := c.String("input")
+	dir := c.String("dir")
+	verbose := c.Bool("verbose")
+	interactive := c.Bool("interactive")
+	startDelim := c.String("startDelim")
+	endDelim := c.String("endDelim")
+	fileSizeLimit := c.String("fileSizeLimit")
+	processTemplates := c.Bool("processTemplates")
 
-    if dir == "" {
-        return fmt.Errorf("--dir is required for template command")
-    }
+	if dir == "" {
+		return fmt.Errorf("--dir is required for template command")
+	}
 
-    // Load defaults from config
-    cfg, _ := services.Load()
-    if cfg == nil {
-        cfg = &domain.Config{}
-    }
-    if startDelim == "" && cfg.StartDelim != "" { startDelim = cfg.StartDelim }
-    if endDelim == "" && cfg.EndDelim != "" { endDelim = cfg.EndDelim }
-    if fileSizeLimit == "" && cfg.FileSizeLimit != "" { fileSizeLimit = cfg.FileSizeLimit }
-    if startDelim == "" { startDelim = "[[" }
-    if endDelim == "" { endDelim = "]]" }
-    if fileSizeLimit == "" { fileSizeLimit = "3 mb" }
+	// Load defaults from config
+	cfg, _ := services.Load()
+	if cfg == nil {
+		cfg = &domain.Config{}
+	}
+	if startDelim == "" && cfg.StartDelim != "" {
+		startDelim = cfg.StartDelim
+	}
+	if endDelim == "" && cfg.EndDelim != "" {
+		endDelim = cfg.EndDelim
+	}
+	if fileSizeLimit == "" && cfg.FileSizeLimit != "" {
+		fileSizeLimit = cfg.FileSizeLimit
+	}
+	if startDelim == "" {
+		startDelim = "[["
+	}
+	if endDelim == "" {
+		endDelim = "]]"
+	}
+	if fileSizeLimit == "" {
+		fileSizeLimit = "3 mb"
+	}
 
-    var parsed domain.InputReplacement
-    var err error
-    if inputFile != "" {
-        parsed, err = t.parser.Parse(inputFile)
-        if err != nil { return err }
-    }
+	var parsed domain.InputReplacement
+	var err error
+	if inputFile != "" {
+		parsed, err = t.parser.Parse(inputFile)
+		if err != nil {
+			return err
+		}
+	}
 
-    // Analyze placeholders in dir
-    counts, err := t.replacer.AnalyzeDir(dir, fileSizeLimit, startDelim, endDelim)
-    if err != nil { return err }
-    if len(counts) == 0 {
-        helpers.Log.Info().Msg("No placeholders found.")
-        return nil
-    }
+	// Analyze placeholders in dir
+	counts, err := t.replacer.AnalyzeDir(dir, fileSizeLimit, startDelim, endDelim)
+	if err != nil {
+		return err
+	}
+	if len(counts) == 0 {
+		helpers.Log.Info().Msg("No placeholders found.")
+		return nil
+	}
 
-    // Merge existing values from parsed file
-    values := map[string]string{}
-    for _, r := range parsed.Variables { values[r.Key] = r.Value }
+	// Merge existing values from parsed file
+	values := map[string]string{}
+	for _, r := range parsed.Variables {
+		values[r.Key] = r.Value
+	}
 
-    // Pretty print summary
-    keys := make([]string, 0, len(counts))
-    for k := range counts { keys = append(keys, k) }
-    sort.Strings(keys)
-    helpers.Log.Info().Msg("Discovered placeholders:")
-    for _, k := range keys {
-        v := values[k]
-        if v == "" { v = "(unset)" }
-        fmt.Printf("  %-24s  matches=%-6d  value=%s\n", k, counts[k], v)
-    }
+	// Pretty print summary
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	helpers.Log.Info().Msg("Discovered placeholders:")
+	for _, k := range keys {
+		v := values[k]
+		if v == "" {
+			v = "(unset)"
+		}
+		fmt.Printf("  %-24s  matches=%-6d  value=%s\n", k, counts[k], v)
+	}
 
-    // Interactive prompt for missing values
-    if interactive {
-        r := bufio.NewReader(os.Stdin)
-        for _, k := range keys {
-            def := values[k]
-            fmt.Printf("Enter value for %s [%s]: ", k, def)
-            s, _ := r.ReadString('\n')
-            s = strings.TrimSpace(s)
-            if s != "" { values[k] = s }
-        }
-        fmt.Println()
-    }
+	// Interactive prompt for missing values
+	if interactive {
+		r := bufio.NewReader(os.Stdin)
+		for _, k := range keys {
+			def := values[k]
+			fmt.Printf("Enter value for %s [%s]: ", k, def)
+			s, _ := r.ReadString('\n')
+			s = strings.TrimSpace(s)
+			if s != "" {
+				values[k] = s
+			}
+		}
+		fmt.Println()
+	}
 
-    // Build replacements with final values (use only discovered keys)
-    final := domain.InputReplacement{}
-    for _, k := range keys {
-        if v, ok := values[k]; ok && v != "" {
-            final.Variables = append(final.Variables, domain.Replacement{Key: k, Value: v})
-        }
-    }
+	// Build replacements with final values (use only discovered keys)
+	final := domain.InputReplacement{}
+	for _, k := range keys {
+		if v, ok := values[k]; ok && v != "" {
+			final.Variables = append(final.Variables, domain.Replacement{Key: k, Value: v})
+		}
+	}
 
-    if len(final.Variables) == 0 {
-        helpers.Log.Info().Msg("No values provided; nothing to replace.")
-        return nil
-    }
+	if len(final.Variables) == 0 {
+		helpers.Log.Info().Msg("No values provided; nothing to replace.")
+		return nil
+	}
 
-    if err := t.replacer.ReplaceInDir(dir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
-        return err
-    }
-    helpers.Log.Info().Msg("Templating complete ✔")
-    return nil
+	if err := t.replacer.ReplaceInDir(dir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+		return err
+	}
+
+	// Process .tpl files if requested
+	if processTemplates {
+		if err := t.replacer.ProcessTemplateFiles(dir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+			return err
+		}
+		helpers.Log.Info().Msg("Template file processing complete ✔")
+	}
+
+	helpers.Log.Info().Msg("Templating complete ✔")
+	return nil
 }

--- a/flags.go
+++ b/flags.go
@@ -65,3 +65,8 @@ var templateNameFlag = cli.StringFlag{
     Value: "",
     Usage: "Template name or URL substring to select non-interactively",
 }
+
+var processTemplatesFlag = cli.BoolFlag{
+    Name:  "processTemplates, pt",
+    Usage: "Process .tpl files by evaluating templates and removing .tpl suffix",
+}

--- a/integration/template_processing_test.go
+++ b/integration/template_processing_test.go
@@ -1,0 +1,318 @@
+package integration
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestTemplateProcessingIntegration(t *testing.T) {
+	bin := buildBinary(t)
+	workDir := t.TempDir()
+
+	// Create test .tpl files
+	tplContent1 := `# [[PROJECT_NAME]]
+
+Welcome to [[PROJECT_NAME]]!
+
+## Configuration
+- App Name: [[APP_NAME:toLowerCase]]
+- Version: [[VERSION:toUpperCase]]
+- Database: [[DB_NAME]]`
+
+	tplContent2 := `package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello from [[APP_NAME]]!")
+    fmt.Println("Version: [[VERSION]]")
+}`
+
+	// Write test files
+	tplFile1 := filepath.Join(workDir, "README.md.tpl")
+	tplFile2 := filepath.Join(workDir, "main.tpl")
+	regularFile := filepath.Join(workDir, "config.txt")
+
+	if err := os.WriteFile(tplFile1, []byte(tplContent1), 0644); err != nil {
+		t.Fatalf("Failed to create README.md.tpl: %v", err)
+	}
+	if err := os.WriteFile(tplFile2, []byte(tplContent2), 0644); err != nil {
+		t.Fatalf("Failed to create main.tpl: %v", err)
+	}
+	if err := os.WriteFile(regularFile, []byte("This is a regular file with [[PLACEHOLDER]]"), 0644); err != nil {
+		t.Fatalf("Failed to create config.txt: %v", err)
+	}
+
+	// Create values file
+	vals := `variables:
+  - key: PROJECT_NAME
+    value: TestProject
+  - key: APP_NAME
+    value: MyApp
+  - key: VERSION
+    value: 1.0.0
+  - key: DB_NAME
+    value: testdb
+  - key: PLACEHOLDER
+    value: replaced_value`
+
+	valsPath := writeFile(t, t.TempDir(), "values.yaml", vals)
+
+	// Run template command with processTemplates flag
+	cmd := exec.Command(bin,
+		"template",
+		"--dir", workDir,
+		"--input", valsPath,
+		"--startDelim", "[[",
+		"--endDelim", "]]",
+		"--processTemplates",
+		"--verbose",
+	)
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("template command failed: %v\n%s", err, string(out))
+	}
+
+	// Check that .tpl files were removed
+	if _, err := os.Stat(tplFile1); err == nil {
+		t.Error("README.md.tpl should have been removed")
+	}
+	if _, err := os.Stat(tplFile2); err == nil {
+		t.Error("main.tpl should have been removed")
+	}
+
+	// Check that new files were created without .tpl suffix
+	readmeFile := filepath.Join(workDir, "README.md")
+	mainFile := filepath.Join(workDir, "main")
+
+	if _, err := os.Stat(readmeFile); err != nil {
+		t.Error("README file should have been created")
+	}
+	if _, err := os.Stat(mainFile); err != nil {
+		t.Error("main file should have been created")
+	}
+
+	// Check content of processed files
+	readmeContent, err := os.ReadFile(readmeFile)
+	if err != nil {
+		t.Fatalf("Failed to read README file: %v", err)
+	}
+
+	expectedReadme := `# TestProject
+
+Welcome to TestProject!
+
+## Configuration
+- App Name: myapp
+- Version: 1.0.0
+- Database: testdb`
+
+	if string(readmeContent) != expectedReadme {
+		t.Errorf("README content mismatch. Expected:\n%s\nGot:\n%s", expectedReadme, string(readmeContent))
+	}
+
+	mainContent, err := os.ReadFile(mainFile)
+	if err != nil {
+		t.Fatalf("Failed to read main file: %v", err)
+	}
+
+	expectedMain := `package main
+
+import "fmt"
+
+func main() {
+    fmt.Println("Hello from MyApp!")
+    fmt.Println("Version: 1.0.0")
+}`
+
+	if string(mainContent) != expectedMain {
+		t.Errorf("main content mismatch. Expected:\n%s\nGot:\n%s", expectedMain, string(mainContent))
+	}
+
+	// Check that regular file was also processed (placeholders replaced)
+	configContent, err := os.ReadFile(regularFile)
+	if err != nil {
+		t.Fatalf("Failed to read config.txt: %v", err)
+	}
+
+	if !bytes.Contains(configContent, []byte("replaced_value")) {
+		t.Error("Regular file should have had placeholders replaced")
+	}
+	if bytes.Contains(configContent, []byte("[[PLACEHOLDER]]")) {
+		t.Error("Regular file should not contain unreplaced placeholders")
+	}
+}
+
+func TestTemplateProcessingWithoutFlag(t *testing.T) {
+	bin := buildBinary(t)
+	workDir := t.TempDir()
+
+	// Create test .tpl file
+	tplContent := `Hello [[NAME]]!`
+	tplFile := filepath.Join(workDir, "test.tpl")
+	if err := os.WriteFile(tplFile, []byte(tplContent), 0644); err != nil {
+		t.Fatalf("Failed to create test.tpl: %v", err)
+	}
+
+	// Create values file
+	vals := `variables:
+  - key: NAME
+    value: World`
+
+	valsPath := writeFile(t, t.TempDir(), "values.yaml", vals)
+
+	// Run template command WITHOUT processTemplates flag
+	cmd := exec.Command(bin,
+		"template",
+		"--dir", workDir,
+		"--input", valsPath,
+		"--startDelim", "[[",
+		"--endDelim", "]]",
+		"--verbose",
+	)
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("template command failed: %v\n%s", err, string(out))
+	}
+
+	// Check that .tpl file was NOT processed (should still exist)
+	if _, err := os.Stat(tplFile); err != nil {
+		t.Error("test.tpl should NOT have been removed when processTemplates flag is not set")
+	}
+
+	// Check that no new file was created
+	newFile := filepath.Join(workDir, "test")
+	if _, err := os.Stat(newFile); err == nil {
+		t.Error("test file should NOT have been created when processTemplates flag is not set")
+	}
+
+	// Check that the .tpl file content was still processed (placeholders replaced)
+	tplContentAfter, err := os.ReadFile(tplFile)
+	if err != nil {
+		t.Fatalf("Failed to read test.tpl: %v", err)
+	}
+
+	if !bytes.Contains(tplContentAfter, []byte("Hello World!")) {
+		t.Error("test.tpl should have had placeholders replaced even without processTemplates flag")
+	}
+}
+
+func TestCloneWithTemplateProcessing(t *testing.T) {
+	bin := buildBinary(t)
+	outDir := t.TempDir()
+
+	// Create a test repository structure
+	testRepoDir := t.TempDir()
+
+	// Create .tpl files in the test repo
+	tplContent1 := `# [[PROJECT_NAME]]
+Version: [[VERSION]]`
+	tplContent2 := `package main
+
+func main() {
+    fmt.Println("[[GREETING]]")
+}`
+
+	tplFile1 := filepath.Join(testRepoDir, "README.md.tpl")
+	tplFile2 := filepath.Join(testRepoDir, "main.tpl")
+
+	if err := os.WriteFile(tplFile1, []byte(tplContent1), 0644); err != nil {
+		t.Fatalf("Failed to create README.md.tpl: %v", err)
+	}
+	if err := os.WriteFile(tplFile2, []byte(tplContent2), 0644); err != nil {
+		t.Fatalf("Failed to create main.tpl: %v", err)
+	}
+
+	// Initialize git repo
+	cmd := exec.Command("git", "init")
+	cmd.Dir = testRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, string(out))
+	}
+
+	// Add files and commit
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = testRepoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git add failed: %v\n%s", err, string(out))
+	}
+
+	cmd = exec.Command("git", "commit", "-m", "Initial commit")
+	cmd.Dir = testRepoDir
+	cmd.Env = append(os.Environ(), "GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com", "GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git commit failed: %v\n%s", err, string(out))
+	}
+
+	// Create values file
+	vals := `variables:
+  - key: PROJECT_NAME
+    value: ClonedProject
+  - key: VERSION
+    value: 2.0.0
+  - key: GREETING
+    value: Hello from cloned project!`
+
+	valsPath := writeFile(t, t.TempDir(), "values.yaml", vals)
+
+	// Clone with template processing
+	cmd = exec.Command(bin,
+		"clone",
+		"--repo", testRepoDir,
+		"--input", valsPath,
+		"--outputDir", outDir,
+		"--startDelim", "[[",
+		"--endDelim", "]]",
+		"--processTemplates",
+		"--verbose",
+	)
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("clone command failed: %v\n%s", err, string(out))
+	}
+
+	// Check that .tpl files were processed
+	readmeFile := filepath.Join(outDir, "README.md")
+	mainFile := filepath.Join(outDir, "main")
+
+	if _, err := os.Stat(readmeFile); err != nil {
+		t.Error("README file should have been created from README.md.tpl")
+	}
+	if _, err := os.Stat(mainFile); err != nil {
+		t.Error("main file should have been created from main.tpl")
+	}
+
+	// Check content
+	readmeContent, err := os.ReadFile(readmeFile)
+	if err != nil {
+		t.Fatalf("Failed to read README: %v", err)
+	}
+
+	expectedReadme := `# ClonedProject
+Version: 2.0.0`
+
+	if string(readmeContent) != expectedReadme {
+		t.Errorf("README content mismatch. Expected:\n%s\nGot:\n%s", expectedReadme, string(readmeContent))
+	}
+
+	mainContent, err := os.ReadFile(mainFile)
+	if err != nil {
+		t.Fatalf("Failed to read main: %v", err)
+	}
+
+	expectedMain := `package main
+
+func main() {
+    fmt.Println("Hello from cloned project!")
+}`
+
+	if string(mainContent) != expectedMain {
+		t.Errorf("main content mismatch. Expected:\n%s\nGot:\n%s", expectedMain, string(mainContent))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,70 +1,88 @@
 package main
 
 import (
-    "fmt"
-    "os"
+	"fmt"
+	"os"
 
-    "github.com/brasa-ai/yankrun/actions"
-    "github.com/brasa-ai/yankrun/helpers"
-    "github.com/brasa-ai/yankrun/services"
+	"github.com/brasa-ai/yankrun/actions"
+	"github.com/brasa-ai/yankrun/helpers"
+	"github.com/brasa-ai/yankrun/services"
 
-    "github.com/urfave/cli"
+	"github.com/urfave/cli"
+)
+
+// Version information - these will be set during build
+var (
+	Version   = "dev"
+	BuildTime = "unknown"
+	GitCommit = "unknown"
 )
 
 func main() {
 	// Instantiate required services
 	fs := &services.OsFileSystem{}
-    parser := &services.YAMLJSONParser{FileSystem: fs}
-    replacer := &services.FileReplacer{FileSystem: fs}
+	parser := &services.YAMLJSONParser{FileSystem: fs}
+	replacer := &services.FileReplacer{FileSystem: fs}
 	cloner := &services.GitCloner{FileSystem: fs}
 
 	// Pass them to actions
-    templateAction := actions.NewTemplateAction(fs, parser, replacer)
-    cloneAction := actions.NewCloneAction(fs, parser, replacer, cloner)
-    generateAction := actions.NewGenerateAction(fs, cloner, parser, replacer)
+	templateAction := actions.NewTemplateAction(fs, parser, replacer)
+	cloneAction := actions.NewCloneAction(fs, parser, replacer, cloner)
+	generateAction := actions.NewGenerateAction(fs, cloner, parser, replacer)
 
-    app := cli.NewApp()
+	app := cli.NewApp()
 	app.Name = "yankrun"
 	app.Usage = "It templates values and repos"
-    // Setup logger using config defaults
-    if cfg, err := services.Load(); err == nil {
-        helpers.SetupLogger("info")
-        _ = cfg // reserved for future loglevel in yankrun
-    } else {
-        helpers.SetupLogger("info")
-    }
-    app.Commands = []cli.Command{
+	app.Version = Version
+	// Setup logger using config defaults
+	if cfg, err := services.Load(); err == nil {
+		helpers.SetupLogger("info")
+		_ = cfg // reserved for future loglevel in yankrun
+	} else {
+		helpers.SetupLogger("info")
+	}
+	app.Commands = []cli.Command{
 		{
 			Name:    "template",
 			Aliases: []string{"t"},
 			Usage:   "Template values",
-            Flags:   []cli.Flag{inputFlag, dirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag},
+			Flags:   []cli.Flag{inputFlag, dirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, processTemplatesFlag},
 			Action:  templateAction.Execute,
 		},
 		{
 			Name:    "clone",
 			Aliases: []string{"r"},
 			Usage:   "Clone a repo with template file replacements",
-            Flags:   []cli.Flag{repoFlag, inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, branchFlag},
+			Flags:   []cli.Flag{repoFlag, inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, branchFlag, processTemplatesFlag},
 			Action:  cloneAction.Execute,
 		},
-        {
-            Name:  "generate",
-            Usage: "Interactively choose a template repo/branch and clone it as a new repo (removes .git)",
-            Flags: []cli.Flag{inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, templateNameFlag, branchFlag},
-            Action: generateAction.Execute,
-        },
-        {
-            Name:  "setup",
-            Usage: "create or update ~/.yankrun/config.yaml (use --show to display, --reset to delete)",
-            Flags: []cli.Flag{
-                &cli.BoolFlag{Name: "show", Usage: "show current configuration"},
-                &cli.BoolFlag{Name: "reset", Usage: "delete ~/.yankrun/config.yaml"},
-            },
-            Action: func(c *cli.Context) error {
-                return actions.RunSetup(os.Args[2:])
-            },
-        },
+		{
+			Name:   "generate",
+			Usage:  "Interactively choose a template repo/branch and clone it as a new repo (removes .git)",
+			Flags:  []cli.Flag{inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, templateNameFlag, branchFlag, processTemplatesFlag},
+			Action: generateAction.Execute,
+		},
+		{
+			Name:  "setup",
+			Usage: "create or update ~/.yankrun/config.yaml (use --show to display, --reset to delete)",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: "show", Usage: "show current configuration"},
+				&cli.BoolFlag{Name: "reset", Usage: "delete ~/.yankrun/config.yaml"},
+			},
+			Action: func(c *cli.Context) error {
+				return actions.RunSetup(os.Args[2:])
+			},
+		},
+		{
+			Name:  "version",
+			Usage: "show version information",
+			Action: func(c *cli.Context) error {
+				fmt.Printf("yankrun version %s\n", Version)
+				fmt.Printf("Build time: %s\n", BuildTime)
+				fmt.Printf("Git commit: %s\n", GitCommit)
+				return nil
+			},
+		},
 	}
 
 	err := app.Run(os.Args)

--- a/services/filesystem.go
+++ b/services/filesystem.go
@@ -14,6 +14,8 @@ type FileSystem interface {
 	Stat(path string) (os.FileInfo, error)
 	EnsureDir(path string) error
 	Join(elem ...string) string
+	Remove(path string) error
+	Base(path string) string
 }
 
 type OsFileSystem struct{}
@@ -57,4 +59,12 @@ func (o *OsFileSystem) EnsureDir(dir string) error {
 
 func (o *OsFileSystem) Join(elem ...string) string {
 	return filepath.Join(elem...)
+}
+
+func (o *OsFileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (o *OsFileSystem) Base(path string) string {
+	return filepath.Base(path)
 }

--- a/services/replacer_test.go
+++ b/services/replacer_test.go
@@ -1,0 +1,325 @@
+package services
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/brasa-ai/yankrun/domain"
+)
+
+func TestProcessTemplateFiles(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create test .tpl files
+	tplContent1 := `Hello [[NAME]]!
+This is a template file with [[PROJECT_NAME]].
+Version: [[VERSION:toUpperCase]]`
+
+	tplContent2 := `Config for [[APP_NAME:toLowerCase]]:
+Database: [[DB_NAME]]
+Port: [[PORT]]`
+
+	// Write test files
+	tplFile1 := filepath.Join(tempDir, "readme.tpl")
+	tplFile2 := filepath.Join(tempDir, "config.tpl")
+	regularFile := filepath.Join(tempDir, "regular.txt")
+
+	if err := os.WriteFile(tplFile1, []byte(tplContent1), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	if err := os.WriteFile(tplFile2, []byte(tplContent2), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	if err := os.WriteFile(regularFile, []byte("This is a regular file"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create replacer instance
+	fs := &OsFileSystem{}
+	replacer := &FileReplacer{FileSystem: fs}
+
+	// Define replacements
+	replacements := domain.InputReplacement{
+		Variables: []domain.Replacement{
+			{Key: "NAME", Value: "John"},
+			{Key: "PROJECT_NAME", Value: "TestProject"},
+			{Key: "VERSION", Value: "1.0.0"},
+			{Key: "APP_NAME", Value: "MyApp"},
+			{Key: "DB_NAME", Value: "testdb"},
+			{Key: "PORT", Value: "8080"},
+		},
+	}
+
+	// Process template files
+	err := replacer.ProcessTemplateFiles(tempDir, replacements, "3 mb", "[[", "]]", false)
+	if err != nil {
+		t.Fatalf("ProcessTemplateFiles failed: %v", err)
+	}
+
+	// Check that .tpl files were removed
+	if _, err := os.Stat(tplFile1); err == nil {
+		t.Error("readme.tpl should have been removed")
+	}
+	if _, err := os.Stat(tplFile2); err == nil {
+		t.Error("config.tpl should have been removed")
+	}
+
+	// Check that new files were created without .tpl suffix
+	readmeFile := filepath.Join(tempDir, "readme")
+	configFile := filepath.Join(tempDir, "config")
+
+	if _, err := os.Stat(readmeFile); err != nil {
+		t.Error("readme file should have been created")
+	}
+	if _, err := os.Stat(configFile); err != nil {
+		t.Error("config file should have been created")
+	}
+
+	// Check content of processed files
+	readmeContent, err := os.ReadFile(readmeFile)
+	if err != nil {
+		t.Fatalf("Failed to read readme file: %v", err)
+	}
+
+	expectedReadme := `Hello John!
+This is a template file with TestProject.
+Version: 1.0.0`
+
+	if string(readmeContent) != expectedReadme {
+		t.Errorf("readme content mismatch. Expected:\n%s\nGot:\n%s", expectedReadme, string(readmeContent))
+	}
+
+	configContent, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("Failed to read config file: %v", err)
+	}
+
+	expectedConfig := `Config for myapp:
+Database: testdb
+Port: 8080`
+
+	if string(configContent) != expectedConfig {
+		t.Errorf("config content mismatch. Expected:\n%s\nGot:\n%s", expectedConfig, string(configContent))
+	}
+
+	// Check that regular file was not affected
+	regularContent, err := os.ReadFile(regularFile)
+	if err != nil {
+		t.Fatalf("Failed to read regular file: %v", err)
+	}
+
+	if string(regularContent) != "This is a regular file" {
+		t.Error("Regular file should not have been modified")
+	}
+}
+
+func TestProcessTemplateFilesWithSubdirectories(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create subdirectories
+	subDir1 := filepath.Join(tempDir, "src")
+	subDir2 := filepath.Join(tempDir, "docs")
+	if err := os.MkdirAll(subDir1, 0755); err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
+	if err := os.MkdirAll(subDir2, 0755); err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
+
+	// Create test .tpl files in subdirectories
+	tplContent1 := `Source file: [[FILE_NAME]]`
+	tplContent2 := `Documentation: [[DOC_TITLE]]`
+
+	tplFile1 := filepath.Join(subDir1, "main.tpl")
+	tplFile2 := filepath.Join(subDir2, "readme.tpl")
+
+	if err := os.WriteFile(tplFile1, []byte(tplContent1), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	if err := os.WriteFile(tplFile2, []byte(tplContent2), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create replacer instance
+	fs := &OsFileSystem{}
+	replacer := &FileReplacer{FileSystem: fs}
+
+	// Define replacements
+	replacements := domain.InputReplacement{
+		Variables: []domain.Replacement{
+			{Key: "FILE_NAME", Value: "app.go"},
+			{Key: "DOC_TITLE", Value: "User Guide"},
+		},
+	}
+
+	// Process template files
+	err := replacer.ProcessTemplateFiles(tempDir, replacements, "3 mb", "[[", "]]", false)
+	if err != nil {
+		t.Fatalf("ProcessTemplateFiles failed: %v", err)
+	}
+
+	// Check that .tpl files were removed
+	if _, err := os.Stat(tplFile1); err == nil {
+		t.Error("main.tpl should have been removed")
+	}
+	if _, err := os.Stat(tplFile2); err == nil {
+		t.Error("readme.tpl should have been removed")
+	}
+
+	// Check that new files were created
+	mainFile := filepath.Join(subDir1, "main")
+	readmeFile := filepath.Join(subDir2, "readme")
+
+	if _, err := os.Stat(mainFile); err != nil {
+		t.Error("main file should have been created")
+	}
+	if _, err := os.Stat(readmeFile); err != nil {
+		t.Error("readme file should have been created")
+	}
+
+	// Check content
+	mainContent, err := os.ReadFile(mainFile)
+	if err != nil {
+		t.Fatalf("Failed to read main file: %v", err)
+	}
+
+	if string(mainContent) != "Source file: app.go" {
+		t.Errorf("main content mismatch. Expected: 'Source file: app.go', Got: '%s'", string(mainContent))
+	}
+
+	readmeContent, err := os.ReadFile(readmeFile)
+	if err != nil {
+		t.Fatalf("Failed to read readme file: %v", err)
+	}
+
+	if string(readmeContent) != "Documentation: User Guide" {
+		t.Errorf("readme content mismatch. Expected: 'Documentation: User Guide', Got: '%s'", string(readmeContent))
+	}
+}
+
+func TestProcessTemplateFilesSkipsIgnoredDirectories(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create ignored directories
+	gitDir := filepath.Join(tempDir, ".git")
+	nodeModulesDir := filepath.Join(tempDir, "node_modules")
+	vendorDir := filepath.Join(tempDir, "vendor")
+
+	if err := os.MkdirAll(gitDir, 0755); err != nil {
+		t.Fatalf("Failed to create .git directory: %v", err)
+	}
+	if err := os.MkdirAll(nodeModulesDir, 0755); err != nil {
+		t.Fatalf("Failed to create node_modules directory: %v", err)
+	}
+	if err := os.MkdirAll(vendorDir, 0755); err != nil {
+		t.Fatalf("Failed to create vendor directory: %v", err)
+	}
+
+	// Create .tpl files in ignored directories
+	tplContent := `This should not be processed: [[VALUE]]`
+
+	gitTplFile := filepath.Join(gitDir, "config.tpl")
+	nodeTplFile := filepath.Join(nodeModulesDir, "package.tpl")
+	vendorTplFile := filepath.Join(vendorDir, "lib.tpl")
+
+	if err := os.WriteFile(gitTplFile, []byte(tplContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	if err := os.WriteFile(nodeTplFile, []byte(tplContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+	if err := os.WriteFile(vendorTplFile, []byte(tplContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create replacer instance
+	fs := &OsFileSystem{}
+	replacer := &FileReplacer{FileSystem: fs}
+
+	// Define replacements
+	replacements := domain.InputReplacement{
+		Variables: []domain.Replacement{
+			{Key: "VALUE", Value: "processed"},
+		},
+	}
+
+	// Process template files
+	err := replacer.ProcessTemplateFiles(tempDir, replacements, "3 mb", "[[", "]]", false)
+	if err != nil {
+		t.Fatalf("ProcessTemplateFiles failed: %v", err)
+	}
+
+	// Check that .tpl files in ignored directories were NOT processed
+	if _, err := os.Stat(gitTplFile); err != nil {
+		t.Error(".git/config.tpl should not have been processed")
+	}
+	if _, err := os.Stat(nodeTplFile); err != nil {
+		t.Error("node_modules/package.tpl should not have been processed")
+	}
+	if _, err := os.Stat(vendorTplFile); err != nil {
+		t.Error("vendor/lib.tpl should not have been processed")
+	}
+}
+
+func TestProcessTemplateFilesWithTransformations(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+
+	// Create test .tpl file with transformations
+	tplContent := `App: [[APP_NAME:toUpperCase]]
+Path: [[PATH:gsub( ,-)]]
+Mixed: [[MIXED:toLowerCase:gsub(test,prod)]]`
+
+	tplFile := filepath.Join(tempDir, "app.tpl")
+	if err := os.WriteFile(tplFile, []byte(tplContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Create replacer instance
+	fs := &OsFileSystem{}
+	replacer := &FileReplacer{FileSystem: fs}
+
+	// Define replacements
+	replacements := domain.InputReplacement{
+		Variables: []domain.Replacement{
+			{Key: "APP_NAME", Value: "myapp"},
+			{Key: "PATH", Value: "src main"},
+			{Key: "MIXED", Value: "TEST_VALUE"},
+		},
+	}
+
+	// Process template files
+	err := replacer.ProcessTemplateFiles(tempDir, replacements, "3 mb", "[[", "]]", false)
+	if err != nil {
+		t.Fatalf("ProcessTemplateFiles failed: %v", err)
+	}
+
+	// Check that .tpl file was removed
+	if _, err := os.Stat(tplFile); err == nil {
+		t.Error("app.tpl should have been removed")
+	}
+
+	// Check that new file was created
+	appFile := filepath.Join(tempDir, "app")
+	if _, err := os.Stat(appFile); err != nil {
+		t.Error("app file should have been created")
+	}
+
+	// Check content with transformations
+	appContent, err := os.ReadFile(appFile)
+	if err != nil {
+		t.Fatalf("Failed to read app file: %v", err)
+	}
+
+	expectedContent := `App: MYAPP
+Path: src-main
+Mixed: prod_value`
+
+	if string(appContent) != expectedContent {
+		t.Errorf("app content mismatch. Expected:\n%s\nGot:\n%s", expectedContent, string(appContent))
+	}
+}


### PR DESCRIPTION
This commit introduces GoReleaser for automated releases and adds the capability to process `.tpl` files.

- **GoReleaser Configuration**:
  - Adds a `.goreleaser.yml` file to automate the building and releasing of the application.
  - Updates the `Makefile` to include version information and release-related targets.
  - Modifies the GitHub Actions release workflow to use the new Makefile targets.

- **Template Processing**:
  - Adds a `--processTemplates` flag to the `template`, `clone`, and `generate` commands.
  - When enabled, the application will process `.tpl` files, replacing placeholders and removing the `.tpl` suffix.
  - Adds new tests for the template processing functionality.

- **Other Changes**:
  - Updates the `README.md` to document the new `--processTemplates` flag.
  - Adds a `version` command to display the application's version information.