### PR TITLE
feat(template): Add --onlyTemplates flag for focused processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Options:
 - `--endDelim`: template end delimiter (default `]]`)
 - `--prompt` (alias: `--interactive`): ask for values before applying
 - `--processTemplates` (alias: `--pt`): process `.tpl` files by evaluating templates and removing `.tpl` suffix
+- `--onlyTemplates` (alias: `--ot`): when used with `--processTemplates`, only process `.tpl` files and ignore all other files
 
 </details>
 
@@ -207,6 +208,9 @@ yankrun template --dir ./project --input values.json --processTemplates --verbos
 
 # Clone and process .tpl files
 yankrun clone --repo https://github.com/user/template.git --input values.yaml --processTemplates
+
+# Process ONLY .tpl files (ignore all other files)
+yankrun template --dir ./project --input values.json --processTemplates --onlyTemplates --verbose
 ```
 
 What it does:
@@ -222,6 +226,8 @@ Example:
 - `src/main.tpl` → `src/main` (with placeholders replaced)
 
 The `--processTemplates` flag is optional and defaults to `false` to maintain backward compatibility.
+
+**Note**: The `--onlyTemplates` flag requires `--processTemplates` to be set. When used together, YankRun will skip processing all non-`.tpl` files and only process template files.
 
 </details>
 

--- a/actions/generate.go
+++ b/actions/generate.go
@@ -1,280 +1,344 @@
 package actions
 
 import (
-    "bufio"
-    "context"
-    "fmt"
-    "os"
-    "path/filepath"
-    "sort"
-    "strings"
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 
-    "github.com/brasa-ai/yankrun/domain"
-    "github.com/brasa-ai/yankrun/helpers"
-    "github.com/brasa-ai/yankrun/services"
-    "github.com/urfave/cli"
+	"github.com/brasa-ai/yankrun/domain"
+	"github.com/brasa-ai/yankrun/helpers"
+	"github.com/brasa-ai/yankrun/services"
+	"github.com/urfave/cli"
 )
 
 type GenerateAction struct {
-    fs       services.FileSystem
-    cloner   services.Cloner
-    parser   services.ReplacementParser
-    replacer services.Replacer
+	fs       services.FileSystem
+	cloner   services.Cloner
+	parser   services.ReplacementParser
+	replacer services.Replacer
 }
 
 func NewGenerateAction(fs services.FileSystem, cloner services.Cloner, parser services.ReplacementParser, replacer services.Replacer) *GenerateAction {
-    return &GenerateAction{fs: fs, cloner: cloner, parser: parser, replacer: replacer}
+	return &GenerateAction{fs: fs, cloner: cloner, parser: parser, replacer: replacer}
 }
 
 // Execute: choose template repo/branch, clone, remove .git, then optionally prompt and apply replacements
 func (a *GenerateAction) Execute(c *cli.Context) error {
-    // parse flags first for non-interactive allowance
-    interactivePrompt := c.Bool("interactive")
-    input := c.String("input")
-    startDelim := c.String("startDelim")
-    endDelim := c.String("endDelim")
-    fileSizeLimit := c.String("fileSizeLimit")
-    verbose := c.Bool("verbose")
-    outputDir := c.String("outputDir")
-    templateFilter := c.String("template")
-    branchFlag := c.String("branch")
-    processTemplates := c.Bool("processTemplates")
+	// parse flags first for non-interactive allowance
+	interactivePrompt := c.Bool("interactive")
+	input := c.String("input")
+	startDelim := c.String("startDelim")
+	endDelim := c.String("endDelim")
+	fileSizeLimit := c.String("fileSizeLimit")
+	verbose := c.Bool("verbose")
+	outputDir := c.String("outputDir")
+	templateFilter := c.String("template")
+	branchFlag := c.String("branch")
+	processTemplates := c.Bool("processTemplates")
+	onlyTemplates := c.Bool("onlyTemplates")
 
-    cfg, err := services.Load()
-    if err != nil {
-        return fmt.Errorf("failed to load config: %w", err)
-    }
-    if len(cfg.Templates) == 0 && cfg.GitHub.User == "" && len(cfg.GitHub.Orgs) == 0 && templateFilter == "" {
-        // Ask minimal discovery setup inline
-        r := bufio.NewReader(os.Stdin)
-        fmt.Println("No templates configured. Let's set where to search:")
-        u := strings.TrimSpace(promptString(r, "GitHub user (optional, Enter to skip)", ""))
-        orgsCSV := strings.TrimSpace(promptString(r, "GitHub orgs (comma-separated, optional)", ""))
-        var orgs []string
-        if orgsCSV != "" {
-            for _, p := range strings.Split(orgsCSV, ",") { if s := strings.TrimSpace(p); s != "" { orgs = append(orgs, s) } }
-        }
-        cfg.GitHub.User = u
-        cfg.GitHub.Orgs = orgs
-        _ = services.Save(cfg)
-    }
+	// Validate flag combination
+	if onlyTemplates && !processTemplates {
+		return fmt.Errorf("--onlyTemplates requires --processTemplates to be set")
+	}
 
-    // flags already parsed above
+	cfg, err := services.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if len(cfg.Templates) == 0 && cfg.GitHub.User == "" && len(cfg.GitHub.Orgs) == 0 && templateFilter == "" {
+		// Ask minimal discovery setup inline
+		r := bufio.NewReader(os.Stdin)
+		fmt.Println("No templates configured. Let's set where to search:")
+		u := strings.TrimSpace(promptString(r, "GitHub user (optional, Enter to skip)", ""))
+		orgsCSV := strings.TrimSpace(promptString(r, "GitHub orgs (comma-separated, optional)", ""))
+		var orgs []string
+		if orgsCSV != "" {
+			for _, p := range strings.Split(orgsCSV, ",") {
+				if s := strings.TrimSpace(p); s != "" {
+					orgs = append(orgs, s)
+				}
+			}
+		}
+		cfg.GitHub.User = u
+		cfg.GitHub.Orgs = orgs
+		_ = services.Save(cfg)
+	}
 
-    // Fill defaults from config
-    if startDelim == "" && cfg.StartDelim != "" { startDelim = cfg.StartDelim }
-    if endDelim == "" && cfg.EndDelim != "" { endDelim = cfg.EndDelim }
-    if fileSizeLimit == "" && cfg.FileSizeLimit != "" { fileSizeLimit = cfg.FileSizeLimit }
-    if startDelim == "" { startDelim = "[[" }
-    if endDelim == "" { endDelim = "]]" }
-    if fileSizeLimit == "" { fileSizeLimit = "3 mb" }
+	// flags already parsed above
 
-    r := bufio.NewReader(os.Stdin)
+	// Fill defaults from config
+	if startDelim == "" && cfg.StartDelim != "" {
+		startDelim = cfg.StartDelim
+	}
+	if endDelim == "" && cfg.EndDelim != "" {
+		endDelim = cfg.EndDelim
+	}
+	if fileSizeLimit == "" && cfg.FileSizeLimit != "" {
+		fileSizeLimit = cfg.FileSizeLimit
+	}
+	if startDelim == "" {
+		startDelim = "[["
+	}
+	if endDelim == "" {
+		endDelim = "]]"
+	}
+	if fileSizeLimit == "" {
+		fileSizeLimit = "3 mb"
+	}
 
-    // Aggregate configured repos + discovered GitHub repos
-    repos := cfg.Templates
-    // Allow direct URL via --template for non-interactive shortcut
-    if templateFilter != "" && (strings.Contains(templateFilter, "://") || strings.HasPrefix(templateFilter, "git@")) {
-        repos = append(repos, domain.TemplateRepo{Name: templateFilter, URL: templateFilter, DefaultBranch: "main"})
-    }
-    if cfg.GitHub.User != "" || len(cfg.GitHub.Orgs) > 0 {
-        ghClient := services.NewGitHubClient()
-        found, _ := ghClient.ListRepos(context.Background(), cfg.GitHub)
-        for _, fr := range found {
-            repos = append(repos, domain.TemplateRepo{
-                Name: fr.FullName, URL: fr.SSHURL, Description: fr.Description, DefaultBranch: fr.DefaultBranch,
-            })
-        }
-    }
-    if len(repos) == 0 {
-        return fmt.Errorf("no templates configured or found")
-    }
+	r := bufio.NewReader(os.Stdin)
 
-    // Build filtered set non-interactively first
-    var filtered []domain.TemplateRepo
-    if templateFilter != "" {
-        for _, t := range repos {
-            if strings.Contains(strings.ToLower(t.Name), strings.ToLower(templateFilter)) || strings.Contains(strings.ToLower(t.URL), strings.ToLower(templateFilter)) {
-                filtered = append(filtered, t)
-            }
-        }
-    } else {
-        filtered = repos
-    }
-    if len(filtered) == 0 {
-        return fmt.Errorf("no templates matched filter")
-    }
+	// Aggregate configured repos + discovered GitHub repos
+	repos := cfg.Templates
+	// Allow direct URL via --template for non-interactive shortcut
+	if templateFilter != "" && (strings.Contains(templateFilter, "://") || strings.HasPrefix(templateFilter, "git@")) {
+		repos = append(repos, domain.TemplateRepo{Name: templateFilter, URL: templateFilter, DefaultBranch: "main"})
+	}
+	if cfg.GitHub.User != "" || len(cfg.GitHub.Orgs) > 0 {
+		ghClient := services.NewGitHubClient()
+		found, _ := ghClient.ListRepos(context.Background(), cfg.GitHub)
+		for _, fr := range found {
+			repos = append(repos, domain.TemplateRepo{
+				Name: fr.FullName, URL: fr.SSHURL, Description: fr.Description, DefaultBranch: fr.DefaultBranch,
+			})
+		}
+	}
+	if len(repos) == 0 {
+		return fmt.Errorf("no templates configured or found")
+	}
 
-    var chosen domain.TemplateRepo
-    if !interactivePrompt && (templateFilter != "" && len(filtered) >= 1) {
-        chosen = filtered[0]
-    } else {
-        helpers.Log.Info().Msg("Available templates:")
-        for i, t := range repos { fmt.Printf("  [%d] %s  (%s)\n", i+1, t.Name, t.URL) }
-        fmt.Printf("Filter templates by substring (press Enter to skip): ")
-        filter, _ := r.ReadString('\n')
-        filter = strings.TrimSpace(filter)
-        filtered = nil
-        if filter == "" { filtered = repos } else {
-            for _, t := range repos {
-                if strings.Contains(strings.ToLower(t.Name), strings.ToLower(filter)) || strings.Contains(strings.ToLower(t.URL), strings.ToLower(filter)) {
-                    filtered = append(filtered, t)
-                }
-            }
-            if len(filtered) == 0 { filtered = repos }
-        }
-        for i, t := range filtered { fmt.Printf("  [%d] %s  (%s)\n", i+1, t.Name, t.URL) }
-        fmt.Printf("Select template [1-%d]: ", len(filtered))
-        selStr, _ := r.ReadString('\n')
-        selStr = strings.TrimSpace(selStr)
-        idx := 0
-        if selStr != "" { fmt.Sscanf(selStr, "%d", &idx); idx-- }
-        if idx < 0 || idx >= len(filtered) { idx = 0 }
-        chosen = filtered[idx]
-    }
+	// Build filtered set non-interactively first
+	var filtered []domain.TemplateRepo
+	if templateFilter != "" {
+		for _, t := range repos {
+			if strings.Contains(strings.ToLower(t.Name), strings.ToLower(templateFilter)) || strings.Contains(strings.ToLower(t.URL), strings.ToLower(templateFilter)) {
+				filtered = append(filtered, t)
+			}
+		}
+	} else {
+		filtered = repos
+	}
+	if len(filtered) == 0 {
+		return fmt.Errorf("no templates matched filter")
+	}
 
-    // Retrieve branches from remote and allow filtering by substring as user types
-    branches, _ := a.cloner.ListRemoteBranches(chosen.URL)
-    if len(branches) == 0 && chosen.DefaultBranch != "" {
-        branches = []string{chosen.DefaultBranch}
-    }
-    // Non-interactive branch selection via flag
-    var br string
-    if !interactivePrompt {
-        if branchFlag != "" {
-            br = branchFlag
-        } else if chosen.DefaultBranch != "" {
-            br = chosen.DefaultBranch
-        } else {
-            br = "main"
-        }
-    } else {
-        fmt.Printf("Type to filter branches (Enter to accept default [%s]): ", chosen.DefaultBranch)
-        branchFilter, _ := r.ReadString('\n')
-        branchFilter = strings.TrimSpace(branchFilter)
-        var candidates []string
-        if branchFilter == "" { candidates = branches } else {
-            for _, b := range branches {
-                if strings.Contains(strings.ToLower(b), strings.ToLower(branchFilter)) { candidates = append(candidates, b) }
-            }
-            if len(candidates) == 0 { candidates = branches }
-        }
-        fmt.Println("Available branches:")
-        for i, b := range candidates { fmt.Printf("  [%d] %s\n", i+1, b) }
-        fmt.Printf("Select branch [1-%d] (Enter for default): ", len(candidates))
-        pick, _ := r.ReadString('\n')
-        pick = strings.TrimSpace(pick)
-        br = chosen.DefaultBranch
-        if pick != "" {
-            var idx int
-            if _, err := fmt.Sscanf(pick, "%d", &idx); err == nil && idx >= 1 && idx <= len(candidates) { br = candidates[idx-1] }
-        }
-    }
+	var chosen domain.TemplateRepo
+	if !interactivePrompt && (templateFilter != "" && len(filtered) >= 1) {
+		chosen = filtered[0]
+	} else {
+		helpers.Log.Info().Msg("Available templates:")
+		for i, t := range repos {
+			fmt.Printf("  [%d] %s  (%s)\n", i+1, t.Name, t.URL)
+		}
+		fmt.Printf("Filter templates by substring (press Enter to skip): ")
+		filter, _ := r.ReadString('\n')
+		filter = strings.TrimSpace(filter)
+		filtered = nil
+		if filter == "" {
+			filtered = repos
+		} else {
+			for _, t := range repos {
+				if strings.Contains(strings.ToLower(t.Name), strings.ToLower(filter)) || strings.Contains(strings.ToLower(t.URL), strings.ToLower(filter)) {
+					filtered = append(filtered, t)
+				}
+			}
+			if len(filtered) == 0 {
+				filtered = repos
+			}
+		}
+		for i, t := range filtered {
+			fmt.Printf("  [%d] %s  (%s)\n", i+1, t.Name, t.URL)
+		}
+		fmt.Printf("Select template [1-%d]: ", len(filtered))
+		selStr, _ := r.ReadString('\n')
+		selStr = strings.TrimSpace(selStr)
+		idx := 0
+		if selStr != "" {
+			fmt.Sscanf(selStr, "%d", &idx)
+			idx--
+		}
+		if idx < 0 || idx >= len(filtered) {
+			idx = 0
+		}
+		chosen = filtered[idx]
+	}
 
-    if outputDir == "" {
-        fmt.Printf("Output directory [./new-project]: ")
-        out, _ := r.ReadString('\n')
-        out = strings.TrimSpace(out)
-        if out == "" { out = "./new-project" }
-        outputDir = out
-    }
+	// Retrieve branches from remote and allow filtering by substring as user types
+	branches, _ := a.cloner.ListRemoteBranches(chosen.URL)
+	if len(branches) == 0 && chosen.DefaultBranch != "" {
+		branches = []string{chosen.DefaultBranch}
+	}
+	// Non-interactive branch selection via flag
+	var br string
+	if !interactivePrompt {
+		if branchFlag != "" {
+			br = branchFlag
+		} else if chosen.DefaultBranch != "" {
+			br = chosen.DefaultBranch
+		} else {
+			br = "main"
+		}
+	} else {
+		fmt.Printf("Type to filter branches (Enter to accept default [%s]): ", chosen.DefaultBranch)
+		branchFilter, _ := r.ReadString('\n')
+		branchFilter = strings.TrimSpace(branchFilter)
+		var candidates []string
+		if branchFilter == "" {
+			candidates = branches
+		} else {
+			for _, b := range branches {
+				if strings.Contains(strings.ToLower(b), strings.ToLower(branchFilter)) {
+					candidates = append(candidates, b)
+				}
+			}
+			if len(candidates) == 0 {
+				candidates = branches
+			}
+		}
+		fmt.Println("Available branches:")
+		for i, b := range candidates {
+			fmt.Printf("  [%d] %s\n", i+1, b)
+		}
+		fmt.Printf("Select branch [1-%d] (Enter for default): ", len(candidates))
+		pick, _ := r.ReadString('\n')
+		pick = strings.TrimSpace(pick)
+		br = chosen.DefaultBranch
+		if pick != "" {
+			var idx int
+			if _, err := fmt.Sscanf(pick, "%d", &idx); err == nil && idx >= 1 && idx <= len(candidates) {
+				br = candidates[idx-1]
+			}
+		}
+	}
 
-    if err := a.fs.EnsureDir(outputDir); err != nil { return err }
+	if outputDir == "" {
+		fmt.Printf("Output directory [./new-project]: ")
+		out, _ := r.ReadString('\n')
+		out = strings.TrimSpace(out)
+		if out == "" {
+			out = "./new-project"
+		}
+		outputDir = out
+	}
 
-    if err := a.cloner.CloneRepositoryBranch(chosen.URL, br, outputDir); err != nil {
-        return err
-    }
-    helpers.Log.Info().Msgf("Cloned %s@%s into %s", chosen.Name, br, outputDir)
+	if err := a.fs.EnsureDir(outputDir); err != nil {
+		return err
+	}
 
-    // Remove .git directory to make it a fresh repo
-    gitDir := filepath.Join(outputDir, ".git")
-    if err := os.RemoveAll(gitDir); err != nil {
-        return fmt.Errorf("failed to remove %s: %w", gitDir, err)
-    }
-    helpers.Log.Info().Msg("Removed .git directory (new repo initialized)")
+	if err := a.cloner.CloneRepositoryBranch(chosen.URL, br, outputDir); err != nil {
+		return err
+	}
+	helpers.Log.Info().Msgf("Cloned %s@%s into %s", chosen.Name, br, outputDir)
 
-    // Parse provided values if any
-    var provided domain.InputReplacement
-    if input != "" {
-        provided, err = a.parser.Parse(input)
-        if err != nil { return err }
-    }
+	// Remove .git directory to make it a fresh repo
+	gitDir := filepath.Join(outputDir, ".git")
+	if err := os.RemoveAll(gitDir); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", gitDir, err)
+	}
+	helpers.Log.Info().Msg("Removed .git directory (new repo initialized)")
 
-    // Analyze placeholders
-    counts, err := a.replacer.AnalyzeDir(outputDir, fileSizeLimit, startDelim, endDelim)
-    if err != nil { return err }
-    if len(counts) == 0 {
-        helpers.Log.Info().Msg("No placeholders found.")
-        return nil
-    }
+	// Parse provided values if any
+	var provided domain.InputReplacement
+	if input != "" {
+		provided, err = a.parser.Parse(input)
+		if err != nil {
+			return err
+		}
+	}
 
-    // Build values map
-    values := map[string]string{}
-    for _, rpl := range provided.Variables { values[rpl.Key] = rpl.Value }
+	// Analyze placeholders
+	counts, err := a.replacer.AnalyzeDir(outputDir, fileSizeLimit, startDelim, endDelim, onlyTemplates)
+	if err != nil {
+		return err
+	}
+	if len(counts) == 0 {
+		helpers.Log.Info().Msg("No placeholders found.")
+		return nil
+	}
 
-    // Show summary
-    keys := make([]string, 0, len(counts))
-    for k := range counts { keys = append(keys, k) }
-    sort.Strings(keys)
-    helpers.Log.Info().Msg("Discovered placeholders:")
-    for _, k := range keys {
-        v := values[k]
-        if v == "" { v = "(unset)" }
-        fmt.Printf("  %-24s  matches=%-6d  value=%s\n", k, counts[k], v)
-    }
+	// Build values map
+	values := map[string]string{}
+	for _, rpl := range provided.Variables {
+		values[rpl.Key] = rpl.Value
+	}
 
-    // Prompt if requested
-    if interactivePrompt {
-        for _, k := range keys {
-            def := values[k]
-            fmt.Printf("Enter value for %s [%s]: ", k, def)
-            s, _ := r.ReadString('\n')
-            s = strings.TrimSpace(s)
-            if s != "" { values[k] = s }
-        }
-        fmt.Println()
-    }
+	// Show summary
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	helpers.Log.Info().Msg("Discovered placeholders:")
+	for _, k := range keys {
+		v := values[k]
+		if v == "" {
+			v = "(unset)"
+		}
+		fmt.Printf("  %-24s  matches=%-6d  value=%s\n", k, counts[k], v)
+	}
 
-    // Build final replacements
-    final := domain.InputReplacement{}
-    for _, k := range keys {
-        if v, ok := values[k]; ok && v != "" {
-            final.Variables = append(final.Variables, domain.Replacement{Key: k, Value: v})
-        }
-    }
+	// Prompt if requested
+	if interactivePrompt {
+		for _, k := range keys {
+			def := values[k]
+			fmt.Printf("Enter value for %s [%s]: ", k, def)
+			s, _ := r.ReadString('\n')
+			s = strings.TrimSpace(s)
+			if s != "" {
+				values[k] = s
+			}
+		}
+		fmt.Println()
+	}
 
-    if len(final.Variables) == 0 {
-        helpers.Log.Info().Msg("No values provided; nothing to replace.")
-        return nil
-    }
+	// Build final replacements
+	final := domain.InputReplacement{}
+	for _, k := range keys {
+		if v, ok := values[k]; ok && v != "" {
+			final.Variables = append(final.Variables, domain.Replacement{Key: k, Value: v})
+		}
+	}
 
-    if err := a.replacer.ReplaceInDir(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
-        return err
-    }
-    
-    // Process .tpl files if requested
-    if processTemplates {
-        if err := a.replacer.ProcessTemplateFiles(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
-            return err
-        }
-        helpers.Log.Info().Msg("Template file processing complete ✔")
-    }
-    
-    helpers.Log.Info().Msg("Templating complete ✔")
-    return nil
+	if len(final.Variables) == 0 {
+		helpers.Log.Info().Msg("No values provided; nothing to replace.")
+		return nil
+	}
+
+	// Skip regular templating if onlyTemplates is set
+	if !onlyTemplates {
+		if err := a.replacer.ReplaceInDir(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+			return err
+		}
+	}
+
+	// Process .tpl files if requested
+	if processTemplates {
+		if err := a.replacer.ProcessTemplateFiles(outputDir, final, fileSizeLimit, startDelim, endDelim, verbose); err != nil {
+			return err
+		}
+		helpers.Log.Info().Msg("Template file processing complete ✔")
+	}
+
+	helpers.Log.Info().Msg("Templating complete ✔")
+	return nil
 }
 
 // promptString reads a line with a label and returns the trimmed value or default when empty
 func promptString(r *bufio.Reader, label string, def string) string {
-    if def == "" {
-        fmt.Printf("%s: ", label)
-    } else {
-        fmt.Printf("%s [%s]: ", label, def)
-    }
-    if v, err := r.ReadString('\n'); err == nil {
-        if s := strings.TrimSpace(v); s != "" { return s }
-    }
-    return def
+	if def == "" {
+		fmt.Printf("%s: ", label)
+	} else {
+		fmt.Printf("%s [%s]: ", label, def)
+	}
+	if v, err := r.ReadString('\n'); err == nil {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return def
 }
-
-

--- a/flags.go
+++ b/flags.go
@@ -21,9 +21,9 @@ var outputDirFlag = cli.StringFlag{
 }
 
 var dirFlag = cli.StringFlag{
-    Name:  "dir, d",
-    Value: "",
-    Usage: "Target directory for templating (used by template command)",
+	Name:  "dir, d",
+	Value: "",
+	Usage: "Target directory for templating (used by template command)",
 }
 
 var verboseFlag = cli.BoolFlag{
@@ -33,40 +33,45 @@ var verboseFlag = cli.BoolFlag{
 
 var fileSizeLimitFlag = cli.StringFlag{
 	Name:  "fileSizeLimit, fl",
-    Value: "3 mb",
+	Value: "3 mb",
 	Usage: "File size limit to ignore replacements from files that exceed the limit",
 }
 
 var startDelimFlag = cli.StringFlag{
-    Name:  "startDelim, sd",
-    Value: "[[",
-    Usage: "Template start delimiter (default [[)",
+	Name:  "startDelim, sd",
+	Value: "[[",
+	Usage: "Template start delimiter (default [[)",
 }
 
 var endDelimFlag = cli.StringFlag{
-    Name:  "endDelim, ed",
-    Value: "]]",
-    Usage: "Template end delimiter (default ]])",
+	Name:  "endDelim, ed",
+	Value: "]]",
+	Usage: "Template end delimiter (default ]])",
 }
 
 var interactiveFlag = cli.BoolFlag{
-    Name:  "interactive, prompt, p",
-    Usage: "Prompt for values for discovered placeholders before applying",
+	Name:  "interactive, prompt, p",
+	Usage: "Prompt for values for discovered placeholders before applying",
 }
 
 var branchFlag = cli.StringFlag{
-    Name:  "branch, b",
-    Value: "",
-    Usage: "Branch to use for generate/clone when non-interactive",
+	Name:  "branch, b",
+	Value: "",
+	Usage: "Branch to use for generate/clone when non-interactive",
 }
 
 var templateNameFlag = cli.StringFlag{
-    Name:  "template, templateName",
-    Value: "",
-    Usage: "Template name or URL substring to select non-interactively",
+	Name:  "template, templateName",
+	Value: "",
+	Usage: "Template name or URL substring to select non-interactively",
 }
 
 var processTemplatesFlag = cli.BoolFlag{
-    Name:  "processTemplates, pt",
-    Usage: "Process .tpl files by evaluating templates and removing .tpl suffix",
+	Name:  "processTemplates, pt",
+	Usage: "Process .tpl files by evaluating templates and removing .tpl suffix",
+}
+
+var onlyTemplatesFlag = cli.BoolFlag{
+	Name:  "onlyTemplates, ot",
+	Usage: "When used with --processTemplates, only process .tpl files and ignore all other files",
 }

--- a/main.go
+++ b/main.go
@@ -46,20 +46,20 @@ func main() {
 			Name:    "template",
 			Aliases: []string{"t"},
 			Usage:   "Template values",
-			Flags:   []cli.Flag{inputFlag, dirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, processTemplatesFlag},
+			Flags:   []cli.Flag{inputFlag, dirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, processTemplatesFlag, onlyTemplatesFlag},
 			Action:  templateAction.Execute,
 		},
 		{
 			Name:    "clone",
 			Aliases: []string{"r"},
 			Usage:   "Clone a repo with template file replacements",
-			Flags:   []cli.Flag{repoFlag, inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, branchFlag, processTemplatesFlag},
+			Flags:   []cli.Flag{repoFlag, inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, branchFlag, processTemplatesFlag, onlyTemplatesFlag},
 			Action:  cloneAction.Execute,
 		},
 		{
 			Name:   "generate",
 			Usage:  "Interactively choose a template repo/branch and clone it as a new repo (removes .git)",
-			Flags:  []cli.Flag{inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, templateNameFlag, branchFlag, processTemplatesFlag},
+			Flags:  []cli.Flag{inputFlag, outputDirFlag, verboseFlag, fileSizeLimitFlag, startDelimFlag, endDelimFlag, interactiveFlag, templateNameFlag, branchFlag, processTemplatesFlag, onlyTemplatesFlag},
 			Action: generateAction.Execute,
 		},
 		{


### PR DESCRIPTION
This commit introduces a new `--onlyTemplates` flag (alias: `--ot`) to the `template`, `clone`, and `generate` commands.

When used in conjunction with the existing `--processTemplates` flag, this new flag instructs the application to process *only* the `.tpl` files in the target directory, skipping all other files. This is useful for scenarios where you want to apply templating to a specific set of files without affecting the rest of the project.

- Added `--onlyTemplates` flag to the CLI.
- Updated the `replacer` service to conditionally skip non-template files during analysis and replacement.
- Added validation to ensure `--onlyTemplates` can only be used with `--processTemplates`.
- Included new integration tests to verify the functionality.
- Updated `README.md` with documentation for the new flag.